### PR TITLE
make location block match uris with query params

### DIFF
--- a/src/conf/zproxy-nginx.conf
+++ b/src/conf/zproxy-nginx.conf
@@ -74,7 +74,7 @@ http {
         location ~ "^/pagespeed_static/" { }
         location ~ "^/ngx_pagespeed_beacon$" { }
 
-        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx|ico)$ {
+        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx|ico)(/?|$) {
             include zope-zproxy-nginx.cfg;
             proxy_set_header Host $myhost;
             expires max;


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-23700  

The regex is updated to match if the file extension is followed by `?` or is the end of the string.