### PR TITLE
Revert "make location block match uris with query params"

### DIFF
--- a/src/conf/zproxy-nginx.conf
+++ b/src/conf/zproxy-nginx.conf
@@ -74,7 +74,7 @@ http {
         location ~ "^/pagespeed_static/" { }
         location ~ "^/ngx_pagespeed_beacon$" { }
 
-        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx|ico)(/?|$) {
+        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx|ico)$ {
             include zope-zproxy-nginx.cfg;
             proxy_set_header Host $myhost;
             expires max;


### PR DESCRIPTION
This reverts commit 0f2827ef1357e42398832e8f4a47babbb08c6380.

Turns out nginx doesnt pass query strings to location blocks, so the last change produced no results.