### PR TITLE
upgrade nginx, lua libraries and pagespeed

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -55,23 +55,23 @@ exportdir               = $(bldtop)/export
 pkg_pypi_url           ?= http://zenpip.zendev.org/packages
 
 nginx                   = nginx
-nginx_version           = 1.7.3
+nginx_version           = 1.10.1
 nginx_pkg               = $(nginx)-$(nginx_version)
 
 nginx_dev               = ngx_devel_kit
-nginx_dev_version       = 0.2.19
+nginx_dev_version       = 0.3.0
 nginx_dev_pkg           = $(nginx_dev)-$(nginx_dev_version)
 
 lua_jit                 = LuaJIT
-lua_jit_version         = 2.0.2
+lua_jit_version         = 2.0.4
 lua_jit_pkg             = $(lua_jit)-$(lua_jit_version)
 
 lua_nginx               = lua-nginx-module
-lua_nginx_version       = 0.9.10
+lua_nginx_version       = 0.10.5
 lua_nginx_pkg           = $(lua_nginx)-$(lua_nginx_version)
 
 lua_resty_redis         = lua-resty-redis
-lua_resty_redis_version = 0.20
+lua_resty_redis_version = 0.24
 lua_resty_redis_pkg     = $(lua_resty_redis)-$(lua_resty_redis_version)
 
 lua_cjson               = lua-cjson
@@ -79,7 +79,7 @@ lua_cjson_version       = 2.1.0
 lua_cjson_pkg           = $(lua_cjson)-$(lua_cjson_version)
 
 ngx_pagespeed           = ngx_pagespeed
-ngx_pagespeed_version   = 1.8.31.4
+ngx_pagespeed_version   = 1.11.33.2
 ngx_pagespeed_pkg       = $(ngx_pagespeed)-$(ngx_pagespeed_version)
 
 


### PR DESCRIPTION
The following libraries have been uploaded to http://zenpip.zendev.org/packages

LuaJIT-2.0.4.tar.gz
lua-nginx-module-0.10.5.tar.gz
lua-resty-redis-0.24.tar.gz
nginx-1.10.1.tar.gz
ngx_devel_kit-0.3.0.tar.gz
ngx_pagespeed-1.11.33.2.tar.gz