### PR TITLE
fix ZEN-27453: add dynamic servers declaration to reporting-Zopes

### DIFF
--- a/src/zproxy
+++ b/src/zproxy
@@ -40,6 +40,12 @@ update_zopes() {
 			reload_nginx
 		fi
 		sleep 5
+		${ZPROXY_HOME}/scripts/update_upstreams 9290 ${ZPROXY_HOME}/conf/zopereports-upstreams.conf
+		if [ $? -eq 2 ]; then
+			echo "$(date) Reloading nginx config due to upstream Reporting-Zope servers change"
+			reload_nginx
+		fi
+		sleep 5
 	done
 }
 


### PR DESCRIPTION
- add call of update_upstreams on zopereports-upstreams.conf
- report requests will dynamically be routed to multiple reporting-Zopes