### PR TITLE
ZEN-27794: add upstream for debugzope and hostname-based proxying to debugzope

### DIFF
--- a/src/conf/zproxy-nginx.conf
+++ b/src/conf/zproxy-nginx.conf
@@ -69,6 +69,17 @@ http {
         keepalive 64;
     }
 
+    upstream debugzopes {
+        least_conn;
+        server 127.0.0.1:9310;
+        keepalive 64;
+    }
+
+    map $host $whichzopes {
+        default zopes;
+        ~*zendebug debugzopes;
+    }
+
     pagespeed ListOutstandingUrlsOnError on;
     pagespeed RewriteDeadlinePerFlushMs 100;
     pagespeed RateLimitBackgroundFetches off;
@@ -109,7 +120,7 @@ http {
         include zopereports-proxy.conf;
 
         location / {
-            proxy_pass http://zopes;
+            proxy_pass http://$whichzopes;
             proxy_set_header Host $myhost;
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
In support of a new service, zendebug, which provides a dedicated Zope instance for debugging the following changes are made:

- add a new upstream for debugzope;
- determine which zope to proxy requests based on hostname